### PR TITLE
feat(film): add filmfest-film microservice structure (#30)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,17 +1,24 @@
 plugins {
     id 'java'
-    id 'application'
     id 'org.springframework.boot' version '3.5.0' apply false
     id 'io.spring.dependency-management' version '1.1.5' apply false
 }
 
-group = 'com.filmfest'
-version = '0.0.1-SNAPSHOT'
+allprojects {
+    group = 'com.filmfest'
+    version = '0.0.1-SNAPSHOT'
 
-repositories {
-    mavenCentral()
+    repositories {
+        mavenCentral()
+    }
 }
 
-application {
-    mainClass = 'com.filmfest.Dummy'
+subprojects {
+    apply plugin: 'java'
+
+    java {
+        toolchain {
+            languageVersion = JavaLanguageVersion.of(21)
+        }
+    }
 }

--- a/filmfest-film/build.gradle
+++ b/filmfest-film/build.gradle
@@ -1,0 +1,43 @@
+plugins {
+	id 'java'
+	id 'org.springframework.boot'
+	id 'io.spring.dependency-management'
+}
+
+group = 'com.filmfest'
+version = '0.0.1-SNAPSHOT'
+
+configurations {
+	compileOnly {
+		extendsFrom annotationProcessor
+	}
+}
+
+repositories {
+	mavenCentral()
+}
+
+dependencies {
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	implementation 'org.springframework.boot:spring-boot-starter-data-mongodb-reactive'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+	implementation 'org.springdoc:springdoc-openapi-starter-webflux-ui:2.8.9'
+	implementation 'org.jsoup:jsoup:1.17.2'
+
+	compileOnly 'org.projectlombok:lombok'
+	developmentOnly 'org.springframework.boot:spring-boot-devtools'
+	annotationProcessor 'org.projectlombok:lombok'
+
+	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'io.projectreactor:reactor-test'
+	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+}
+
+tasks.named('test') {
+	useJUnitPlatform()
+}
+
+tasks.withType(JavaCompile) {
+	options.compilerArgs += ['-Xlint:unchecked']
+}

--- a/filmfest-film/src/main/java/com/filmfest/FilmfestFilmApplication.java
+++ b/filmfest-film/src/main/java/com/filmfest/FilmfestFilmApplication.java
@@ -1,0 +1,13 @@
+package com.filmfest;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class FilmfestFilmApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(FilmfestFilmApplication.class, args);
+	}
+
+}

--- a/filmfest-film/src/main/resources/application.properties
+++ b/filmfest-film/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+spring.application.name=filmfest-film

--- a/filmfest-film/src/test/java/com/filmfest/FilmfestFilmApplicationTests.java
+++ b/filmfest-film/src/test/java/com/filmfest/FilmfestFilmApplicationTests.java
@@ -1,0 +1,13 @@
+package com.filmfest;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class FilmfestFilmApplicationTests {
+
+	@Test
+	void contextLoads() {
+	}
+
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,2 @@
 rootProject.name = 'filmfest-backend'
+include 'filmfest-film'

--- a/src/main/java/com/filmfest/Dummy.java
+++ b/src/main/java/com/filmfest/Dummy.java
@@ -1,7 +1,0 @@
-package com.filmfest;
-
-public class Dummy {
-    public static void main(String[] args) {
-        System.out.println("Hello world.");
-    }
-}


### PR DESCRIPTION
### add filmfest-film microservice structure
User Story: #30 [https://tree.taiga.io/project/tonijimenez72-filmer/task/30](url)

This PR introduces the initial setup of the filmfest-film microservice as part of the filmfest-backend multi-module Gradle project.

### Included Changes
- Added filmfest-film module generated via Spring Initializr.
- Integrated the module into the root settings.gradle.
- Removed redundant files from filmfest-film: .gitignore, settings.gradle, gradlew, gradlew.bat, gradle/
- Ensured that the microservice builds successfully with ./gradlew build.
- Verified correct module structure:
  - Refactored the build.gradle of the filmfest-film module.
  - "src/main/java and resources".
  - "src/test/java".

