### PR TITLE
feat: add filmfest-user model layer (#35)

### DIFF
--- a/filmfest-user/src/main/java/com/filmfest/user/model/User.java
+++ b/filmfest-user/src/main/java/com/filmfest/user/model/User.java
@@ -1,0 +1,29 @@
+package com.filmfest.user.model;
+
+import com.filmfest.user.model.enums.AppLanguage;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.Indexed;
+import org.springframework.data.mongodb.core.mapping.Document;
+import java.util.List;
+import java.util.UUID;
+
+@AllArgsConstructor
+@Data
+@Builder
+@NoArgsConstructor
+@Document(collection="users")
+public class User {
+    
+    @Id
+    private UUID uuid;
+    
+    @Indexed(unique = true)
+    private String username;
+    
+    private List<UserFilm> userFilms;
+    private AppLanguage appLanguage;
+}

--- a/filmfest-user/src/main/java/com/filmfest/user/model/UserFilm.java
+++ b/filmfest-user/src/main/java/com/filmfest/user/model/UserFilm.java
@@ -1,0 +1,20 @@
+package com.filmfest.user.model;
+
+import com.filmfest.user.model.enums.UserFilmStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+
+@AllArgsConstructor
+@Data
+@Builder
+@NoArgsConstructor
+public class UserFilm {
+    @Id
+    private String id;
+    
+    @Builder.Default
+    private UserFilmStatus userFilmStatus=UserFilmStatus.UNSEEN;
+}

--- a/filmfest-user/src/main/java/com/filmfest/user/model/enums/AppLanguage.java
+++ b/filmfest-user/src/main/java/com/filmfest/user/model/enums/AppLanguage.java
@@ -1,0 +1,5 @@
+package com.filmfest.user.model.enums;
+
+public enum AppLanguage {
+    ESP, CAT, ENG
+}

--- a/filmfest-user/src/main/java/com/filmfest/user/model/enums/AppLanguage.java
+++ b/filmfest-user/src/main/java/com/filmfest/user/model/enums/AppLanguage.java
@@ -1,5 +1,5 @@
 package com.filmfest.user.model.enums;
 
 public enum AppLanguage {
-    ESP, CAT, ENG
+    CA, EN, ES
 }

--- a/filmfest-user/src/main/java/com/filmfest/user/model/enums/UserFilmStatus.java
+++ b/filmfest-user/src/main/java/com/filmfest/user/model/enums/UserFilmStatus.java
@@ -1,0 +1,5 @@
+package com.filmfest.user.model.enums;
+
+public enum UserFilmStatus {
+    LIKE, DISLIKE, UNSEEN, MEH
+}


### PR DESCRIPTION

## feat: add filmfest-user model layer (#35)

Contains the core domain entities, annotated with @Document for MongoDB persistence.
Taiga Task: #35 [https://tree.taiga.io/project/tonijimenez72-filmer/task/35](url)

### Changes
- Added models with :
  - User: Represents all user info.
  - UserFilm: Represents the status of each film in the user’s film list.
- Added enums with :
  - AppLanguage: Represents the language of the app (ESP, CAT, ENG)
  - UserFilmStatus: Represents the different states of a film (LIKE, DISLIKE, UNSEEN, MEH).