### PR TITLE
feat: add filmfest-film dto and mapper layers (#41)

### DIFF
--- a/filmfest-film/src/main/java/com/filmfest/film/dto/FilmDetailDto.java
+++ b/filmfest-film/src/main/java/com/filmfest/film/dto/FilmDetailDto.java
@@ -4,6 +4,8 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
@@ -15,6 +17,6 @@ public class FilmDetailDto {
     private String posterUrl;
     private String director;
     private int year;
-    private String country;
+    private List<String> country;
     private String url;
 }

--- a/filmfest-film/src/main/java/com/filmfest/film/dto/FilmDetailDto.java
+++ b/filmfest-film/src/main/java/com/filmfest/film/dto/FilmDetailDto.java
@@ -1,0 +1,20 @@
+package com.filmfest.film.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class FilmDetailDto {
+    private String language;
+    private String title;
+    private String synopsis;
+    private String duration;
+    private String posterUrl;
+    private String director;
+    private int year;
+    private String country;
+    private String url;
+}

--- a/filmfest-film/src/main/java/com/filmfest/film/dto/FilmUrlDto.java
+++ b/filmfest-film/src/main/java/com/filmfest/film/dto/FilmUrlDto.java
@@ -1,0 +1,14 @@
+package com.filmfest.film.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class FilmUrlDto {
+    private String urlCa;
+    private String urlEn;
+    private String urlEs;
+}

--- a/filmfest-film/src/main/java/com/filmfest/film/mapper/FilmDetailMapper.java
+++ b/filmfest-film/src/main/java/com/filmfest/film/mapper/FilmDetailMapper.java
@@ -1,0 +1,52 @@
+package com.filmfest.film.mapper;
+
+import com.filmfest.film.dto.FilmDetailDto;
+import com.filmfest.film.model.FilmDetail;
+
+public class FilmDetailMapper {
+
+    private FilmDetailMapper() {
+        // Prevent instantiation
+    }
+
+    public static FilmDetail toEntity(FilmDetailDto dto) {
+        return FilmDetail.builder()
+                .language(dto.getLanguage())
+                .title(dto.getTitle())
+                .synopsis(dto.getSynopsis())
+                .duration(dto.getDuration())
+                .posterUrl(dto.getPosterUrl())
+                .director(dto.getDirector())
+                .year(dto.getYear())
+                .country(dto.getCountry())
+                .url(dto.getUrl())
+                .id(dto.getUrl())
+                .build();
+    }
+
+    public static FilmDetailDto toDto(FilmDetail entity) {
+        return new FilmDetailDto(
+                entity.getLanguage(),
+                entity.getTitle(),
+                entity.getSynopsis(),
+                entity.getDuration(),
+                entity.getPosterUrl(),
+                entity.getDirector(),
+                entity.getYear(),
+                entity.getCountry(),
+                entity.getUrl()
+        );
+    }
+
+    /*
+    private String language;
+    private String title;
+    private String synopsis;
+    private String duration;
+    private String posterUrl;
+    private String director;
+    private int year;
+    private String country;
+    private String url;
+     */
+}

--- a/filmfest-film/src/main/java/com/filmfest/film/mapper/FilmDetailMapper.java
+++ b/filmfest-film/src/main/java/com/filmfest/film/mapper/FilmDetailMapper.java
@@ -6,7 +6,6 @@ import com.filmfest.film.model.FilmDetail;
 public class FilmDetailMapper {
 
     private FilmDetailMapper() {
-        // Prevent instantiation
     }
 
     public static FilmDetail toEntity(FilmDetailDto dto) {
@@ -37,16 +36,4 @@ public class FilmDetailMapper {
                 entity.getUrl()
         );
     }
-
-    /*
-    private String language;
-    private String title;
-    private String synopsis;
-    private String duration;
-    private String posterUrl;
-    private String director;
-    private int year;
-    private String country;
-    private String url;
-     */
 }

--- a/filmfest-film/src/main/java/com/filmfest/film/mapper/FilmUrlMapper.java
+++ b/filmfest-film/src/main/java/com/filmfest/film/mapper/FilmUrlMapper.java
@@ -1,0 +1,39 @@
+package com.filmfest.film.mapper;
+
+import com.filmfest.film.dto.FilmUrlDto;
+import com.filmfest.film.model.FilmUrl;
+
+import java.util.Map;
+
+public class FilmUrlMapper {
+
+    private FilmUrlMapper() {
+    }
+
+    @SuppressWarnings("unchecked")
+    public static FilmUrlDto fromMap(Map<String, Object> filmData) {
+        Map<String, String> urlMap = (Map<String, String>) filmData.get("url");
+
+        return new FilmUrlDto(
+                urlMap.get("ca"),
+                urlMap.get("en"),
+                urlMap.get("es")
+        );
+    }
+
+    public static FilmUrl toEntity(FilmUrlDto dto) {
+        return FilmUrl.builder()
+                .fullUrlCa(dto.getUrlCa())
+                .fullUrlEn(dto.getUrlEn())
+                .fullUrlEs(dto.getUrlEs())
+                .build();
+    }
+
+    public static FilmUrlDto toDto(FilmUrl entity) {
+        return new FilmUrlDto(
+                entity.getFullUrlCa(),
+                entity.getFullUrlEn(),
+                entity.getFullUrlEs()
+        );
+    }
+}

--- a/filmfest-film/src/main/java/com/filmfest/film/model/FilmDetail.java
+++ b/filmfest-film/src/main/java/com/filmfest/film/model/FilmDetail.java
@@ -26,6 +26,6 @@ public class FilmDetail {
     private String director;
     private String posterUrl;
     private String url;
-    private String country;
+    private List<String> country;
     private int year;
 }

--- a/filmfest-film/src/main/java/com/filmfest/film/model/FilmDetail.java
+++ b/filmfest-film/src/main/java/com/filmfest/film/model/FilmDetail.java
@@ -26,6 +26,6 @@ public class FilmDetail {
     private String director;
     private String posterUrl;
     private String url;
-    private List<String> country;
+    private String country;
     private int year;
 }


### PR DESCRIPTION
## feat: add filmfest-film dto and mapper layers (#41)

User Story: #41 [https://tree.taiga.io/project/tonijimenez72-filmer/task/41](url)

This PR introduces the DTO and Mapper layers for the filmfest-film microservice. It includes:

### Changes
- FilmUrlDto and FilmDetailDto classes to define clean data structures for API and internal use.
- FilmUrlMapper and FilmDetailMapper classes to handle conversions between DTOs and domain models.
- Refactorized List<String> country to String country in FilmDetail class.