### PR TITLE
feat: add filmfest-user dto and mapper layers (#42)

### DIFF
--- a/filmfest-user/src/main/java/com/filmfest/user/dto/UserDto.java
+++ b/filmfest-user/src/main/java/com/filmfest/user/dto/UserDto.java
@@ -1,0 +1,20 @@
+package com.filmfest.user.dto;
+
+import com.filmfest.user.model.UserFilm;
+import com.filmfest.user.model.enums.AppLanguage;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import java.util.List;
+import java.util.UUID;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserDto {
+    private UUID uuid;
+    private String username;
+    private List<UserFilm> userFilms;
+    private AppLanguage appLanguage;
+}

--- a/filmfest-user/src/main/java/com/filmfest/user/mapper/UserMapper.java
+++ b/filmfest-user/src/main/java/com/filmfest/user/mapper/UserMapper.java
@@ -1,0 +1,27 @@
+package com.filmfest.user.mapper;
+
+import com.filmfest.user.dto.UserDto;
+import com.filmfest.user.model.User;
+
+public class UserMapper {
+    public UserMapper() {
+    }
+    
+    public static User toEntity(UserDto dto) {
+        return User.builder()
+                .uuid(dto.getUuid())
+                .username(dto.getUsername())
+                .userFilms(dto.getUserFilms())
+                .appLanguage(dto.getAppLanguage())
+                .build();
+    }
+    
+    public static UserDto toDto(User user) {
+        return new UserDto(
+                user.getUuid(),
+                user.getUsername(),
+                user.getUserFilms(),
+                user.getAppLanguage()
+        );
+    }
+}

--- a/filmfest-user/src/main/java/com/filmfest/user/repository/UserRepository.java
+++ b/filmfest-user/src/main/java/com/filmfest/user/repository/UserRepository.java
@@ -1,9 +1,0 @@
-package com.filmfest.user.repository;
-
-import com.filmfest.user.model.User;
-import org.springframework.data.mongodb.repository.ReactiveMongoRepository;
-
-import java.util.UUID;
-
-public interface UserRepository extends ReactiveMongoRepository<User, UUID> {
-}

--- a/filmfest-user/src/main/java/com/filmfest/user/repository/UserRepository.java
+++ b/filmfest-user/src/main/java/com/filmfest/user/repository/UserRepository.java
@@ -1,0 +1,9 @@
+package com.filmfest.user.repository;
+
+import com.filmfest.user.model.User;
+import org.springframework.data.mongodb.repository.ReactiveMongoRepository;
+
+import java.util.UUID;
+
+public interface UserRepository extends ReactiveMongoRepository<User, UUID> {
+}


### PR DESCRIPTION
## feat: add filmfest-user dto and mapper layers (#42)

User Story: #41 [https://tree.taiga.io/project/tonijimenez72-filmer/task/42](url)

This PR introduces the DTO and Mapper layers for the filmfest-user microservice. It includes:

### Changes
- UserDto class to define clean data structures for API and internal use.
- UserMapperclassto handle conversions between DTOs and domain models.