### PR TITLE
feat: add filmfest-film service and controller layers (#24)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.3.12'
+    id 'org.springframework.boot' version '3.5.0'
     id 'io.spring.dependency-management' version '1.1.7'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,22 +1,15 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.5.0'
-    id 'io.spring.dependency-management' version '1.1.7'
+    id 'org.springframework.boot' version '3.5.0' apply false
+    id 'io.spring.dependency-management' version '1.1.7' apply false
 }
 
 group = 'com.filmfest.backend'
 version = '0.0.1-SNAPSHOT'
 
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
-    }
-}
+repositories { mavenCentral() }
 
-dependencies {
-    implementation 'org.springframework.boot:spring-boot-starter'
-}
-
-repositories {
-    mavenCentral()
+subprojects {
+    apply plugin: 'java'
+    repositories { mavenCentral() }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,24 +1,22 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.5.0' apply false
-    id 'io.spring.dependency-management' version '1.1.5' apply false
+    id 'org.springframework.boot' version '3.3.12'
+    id 'io.spring.dependency-management' version '1.1.7'
 }
 
-allprojects {
-    group = 'com.filmfest'
-    version = '0.0.1-SNAPSHOT'
+group = 'com.filmfest.backend'
+version = '0.0.1-SNAPSHOT'
 
-    repositories {
-        mavenCentral()
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
     }
 }
 
-subprojects {
-    apply plugin: 'java'
+dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter'
+}
 
-    java {
-        toolchain {
-            languageVersion = JavaLanguageVersion.of(21)
-        }
-    }
+repositories {
+    mavenCentral()
 }

--- a/filmfest-film/build.gradle
+++ b/filmfest-film/build.gradle
@@ -28,7 +28,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-mongodb-reactive'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
-	implementation 'org.springdoc:springdoc-openapi-starter-webflux-ui:2.3.0'
+	implementation 'org.springdoc:springdoc-openapi-starter-webflux-ui:2.8.9'
 	implementation 'org.jsoup:jsoup:1.17.2'
 
 	compileOnly 'org.projectlombok:lombok'

--- a/filmfest-film/build.gradle
+++ b/filmfest-film/build.gradle
@@ -1,8 +1,10 @@
-apply plugin: 'java'
-apply plugin: 'org.springframework.boot'
-apply plugin: 'io.spring.dependency-management'
+plugins {
+	id 'java'
+	id 'org.springframework.boot'
+	id 'io.spring.dependency-management'
+}
 
-group = 'com.filmfest.film'
+group = 'com.filmfest'
 version = '0.0.1-SNAPSHOT'
 
 java {
@@ -23,18 +25,32 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
-	implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
+	implementation 'org.springframework.boot:spring-boot-starter-data-mongodb-reactive'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+	implementation 'org.springdoc:springdoc-openapi-starter-webflux-ui:2.3.0'
+	implementation 'org.jsoup:jsoup:1.17.2'
+
 	compileOnly 'org.projectlombok:lombok'
-	developmentOnly 'org.springframework.boot:spring-boot-devtools'
-	annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 	annotationProcessor 'org.projectlombok:lombok'
+	developmentOnly 'org.springframework.boot:spring-boot-devtools'
+
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'io.projectreactor:reactor-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	testImplementation 'org.junit.jupiter:junit-jupiter-api:5.10.2'
+	testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.10.2'
+	testImplementation 'org.mockito:mockito-core:5.12.0'
 }
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+jar {
+	manifest {
+		attributes(
+				'Main-Class': 'com.filmfest.film.App'
+		)
+	}
 }

--- a/filmfest-film/src/main/java/com/filmfest/film/controller/FilmController.java
+++ b/filmfest-film/src/main/java/com/filmfest/film/controller/FilmController.java
@@ -1,0 +1,51 @@
+package com.filmfest.film.controller;
+
+import com.filmfest.film.service.DatabaseAdminService;
+import com.filmfest.film.service.FilmDetailScraperService;
+import com.filmfest.film.service.FilmUrlScraperService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.*;
+import reactor.core.publisher.Mono;
+
+@RestController
+@RequestMapping("/api/films")
+@RequiredArgsConstructor
+public class FilmController {
+
+    private final FilmUrlScraperService filmUrlScraperService;
+    private final FilmDetailScraperService filmDetailScraperService;
+    private final DatabaseAdminService databaseAdminService;
+
+    @Operation(
+            summary = "Import films for a given year from the Sitges Film Festival",
+            description = "Fetches film URLs for the specified year from the Sitges Film Festival website, search detailed metadata (title, synopsis, duration, etc.), and saves the results to MongoDB."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Search and saving process completed successfully"),
+            @ApiResponse(responseCode = "500", description = "Unexpected error during search or persistence")
+    })
+    @PostMapping(value = "/imports/{year}", produces = MediaType.APPLICATION_JSON_VALUE)
+    public Mono<Void> scrapeAndSaveAll(@PathVariable int year) {
+        return filmUrlScraperService.scrapeAndSaveFilmUrls(year)
+                .then(filmDetailScraperService.scrapeAndSaveFilmDetails());
+    }
+
+    @Operation(
+            summary = "Clear films database",
+            description = "Deletes all film data from the MongoDB collection 'films'."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "Database cleared successfully"),
+            @ApiResponse(responseCode = "500", description = "Internal server error")
+    })
+    @DeleteMapping
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public Mono<Void> clearDatabase() {
+        return databaseAdminService.clearDatabase();
+    }
+}

--- a/filmfest-film/src/main/java/com/filmfest/film/service/DatabaseAdminService.java
+++ b/filmfest-film/src/main/java/com/filmfest/film/service/DatabaseAdminService.java
@@ -1,0 +1,7 @@
+package com.filmfest.film.service;
+
+import reactor.core.publisher.Mono;
+
+public interface DatabaseAdminService {
+    Mono<Void> clearDatabase();
+}

--- a/filmfest-film/src/main/java/com/filmfest/film/service/FilmDetailScraperService.java
+++ b/filmfest-film/src/main/java/com/filmfest/film/service/FilmDetailScraperService.java
@@ -1,0 +1,7 @@
+package com.filmfest.film.service;
+
+import reactor.core.publisher.Mono;
+
+public interface FilmDetailScraperService {
+    Mono<Void> scrapeAndSaveFilmDetails();
+}

--- a/filmfest-film/src/main/java/com/filmfest/film/service/FilmUrlScraperService.java
+++ b/filmfest-film/src/main/java/com/filmfest/film/service/FilmUrlScraperService.java
@@ -1,0 +1,7 @@
+package com.filmfest.film.service;
+
+import reactor.core.publisher.Mono;
+
+public interface FilmUrlScraperService {
+    Mono<Void> scrapeAndSaveFilmUrls(int year);
+}

--- a/filmfest-film/src/main/java/com/filmfest/film/service/impl/DatabaseAdminServiceImpl.java
+++ b/filmfest-film/src/main/java/com/filmfest/film/service/impl/DatabaseAdminServiceImpl.java
@@ -1,0 +1,27 @@
+package com.filmfest.film.service.impl;
+
+import com.filmfest.film.service.DatabaseAdminService;
+import org.springframework.data.mongodb.core.ReactiveMongoTemplate;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+@Service
+public class DatabaseAdminServiceImpl implements DatabaseAdminService {
+
+    private static final String FILM_URLS = "film_urls";
+    private static final String FILM_DETAILS = "film_details";
+
+    private final ReactiveMongoTemplate mongoTemplate;
+
+    public DatabaseAdminServiceImpl(ReactiveMongoTemplate mongoTemplate) {
+        this.mongoTemplate = mongoTemplate;
+    }
+
+    @Override
+    public Mono<Void> clearDatabase() {
+        return Mono.when(
+                mongoTemplate.dropCollection(FILM_URLS),
+                mongoTemplate.dropCollection(FILM_DETAILS)
+        ).then();
+    }
+}

--- a/filmfest-film/src/main/java/com/filmfest/film/service/impl/FilmDetailScraperServiceImpl.java
+++ b/filmfest-film/src/main/java/com/filmfest/film/service/impl/FilmDetailScraperServiceImpl.java
@@ -1,0 +1,185 @@
+package com.filmfest.film.service.impl;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.filmfest.film.exception.custom.CustomBadRequestException;
+import com.filmfest.film.model.FilmDetail;
+import com.filmfest.film.repository.FilmDetailRepository;
+import com.filmfest.film.repository.FilmUrlRepository;
+import com.filmfest.film.service.FilmDetailScraperService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+import reactor.util.retry.Retry;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class FilmDetailScraperServiceImpl implements FilmDetailScraperService {
+
+    private final FilmUrlRepository filmUrlRepository;
+    private final FilmDetailRepository filmDetailRepository;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final WebClient webClient = WebClient.builder()
+            .codecs(config -> config.defaultCodecs().maxInMemorySize(5 * 1024 * 1024))
+            .build();
+
+    @Override
+    public Mono<Void> scrapeAndSaveFilmDetails() {
+        AtomicInteger successCount = new AtomicInteger(0);
+        AtomicInteger notFoundCount = new AtomicInteger(0);
+        AtomicInteger errorCount = new AtomicInteger(0);
+
+        return getLanguageUrls()
+                .flatMap(this::processUrl)
+                .doOnNext(detail -> {
+                    if (detail != null) successCount.incrementAndGet();
+                    else notFoundCount.incrementAndGet();
+                })
+                .flatMap(detail -> detail != null ? filmDetailRepository.save(detail) : Mono.empty())
+                .onErrorContinue((ex, obj) -> errorCount.incrementAndGet())
+                .then()
+                .doFinally(signal -> {
+                    log.info("Success: {}", successCount.get());
+                    log.warn("Not Found (no Movie): {}", notFoundCount.get());
+                    log.error("Errors: {}", errorCount.get());
+                });
+    }
+
+    private Flux<LanguageUrl> getLanguageUrls() {
+        return filmUrlRepository.findAll()
+                .flatMap(url -> Flux.just(
+                        new LanguageUrl("ca", url.getFullUrlCa()),
+                        new LanguageUrl("es", url.getFullUrlEs()),
+                        new LanguageUrl("en", url.getFullUrlEn())
+                ));
+    }
+
+    private Mono<FilmDetail> processUrl(LanguageUrl langUrl) {
+        return Mono.fromCallable(() -> {
+            Document doc = Jsoup.connect(langUrl.url()).get();
+            Element jsonLdElement = doc.selectFirst("script[type=application/ld+json]");
+            if (jsonLdElement == null) return null;
+
+            JsonNode root = objectMapper.readTree(jsonLdElement.html());
+            JsonNode graph = root.path("@graph");
+            if (!graph.isArray()) return null;
+
+            for (JsonNode node : graph) {
+                if ("Movie".equals(node.path("@type").asText())) {
+                    return buildFilmDetail(node, langUrl.language(), doc, langUrl.url());
+                }
+            }
+            return null;
+        }).subscribeOn(Schedulers.boundedElastic());
+    }
+
+    private FilmDetail buildFilmDetail(JsonNode node, String language, Document doc, String url) {
+        String title = node.path("name").asText().replace(" |", "").trim();
+        String synopsis = node.path("description").asText();
+        String duration = parseDuration(node.path("duration").asText());
+        String posterUrl = node.path("image").path("url").asText();
+        String director = extractDirector(node, doc);
+        String yearText = extractYear(doc);
+
+        List<String> countries = extractCountries(doc);
+
+        return FilmDetail.builder()
+                .id(url)
+                .language(language)
+                .title(title)
+                .synopsis(synopsis)
+                .duration(duration)
+                .posterUrl(posterUrl)
+                .director(director)
+                .year(parseYear(yearText))
+                .country(countries)
+                .url(url)
+                .build();
+    }
+
+    private String parseDuration(String rawDuration) {
+        if (rawDuration == null || !rawDuration.startsWith("PT")) return "";
+        String minutes = rawDuration.replace("PT", "").replace("S", "");
+        return minutes + " min";
+    }
+
+    private int parseYear(String yearText) {
+        try {
+            return Integer.parseInt(yearText.trim());
+        } catch (Exception e) {
+            return 0;
+        }
+    }
+
+    private String extractDirector(JsonNode node, Document doc) {
+        String director = node.path("director").path("name").asText();
+        if (director != null && !director.isBlank()) {
+            return director;
+        }
+
+        Element dirBlock = doc.selectFirst(".field--name-field-multi-credits");
+        if (dirBlock != null && dirBlock.text().toLowerCase().contains("dirección")) {
+            return Arrays.stream(dirBlock.html().split("<br>"))
+                    .skip(1)
+                    .map(raw -> raw.replaceAll("<[^>]*>", "").trim())
+                    .filter(s -> !s.isBlank())
+                    .findFirst()
+                    .orElse("");
+        }
+
+        return "";
+    }
+
+    private static String extractYear(Document doc) {
+        return doc.selectFirst(".field--name-field-production-year .field__item") != null
+                ? doc.selectFirst(".field--name-field-production-year .field__item").text()
+                : "";
+    }
+
+    private static List<String> extractCountries(Document doc) {
+        return doc.select(".field--name-field-ref-film-countries .field__item").stream()
+                .map(Element::text)
+                .collect(Collectors.toList());
+    }
+
+    private record LanguageUrl(String language, String url) {
+    }
+
+    private Mono<FilmDetail> scrapeFilmDetails(String lang, String url) {
+        return webClient.get()
+                .uri(url)
+                .retrieve()
+                .bodyToMono(String.class)
+                .map(html -> parseHtmlToFilmDetail(lang, html, url))
+                .retryWhen(Retry.backoff(10, Duration.ofSeconds(10))
+                        .filter(this::isRetryable)
+                        .onRetryExhaustedThrow((retryBackoffSpec, signal) -> {
+                            log.error("Retries exhausted for URL: {}", url, signal.failure());
+                            return new CustomBadRequestException("Failed after retries: " + url);
+                        })
+                );
+    }
+
+    private boolean isRetryable(Throwable throwable) {
+        return throwable instanceof java.io.IOException ||
+                throwable instanceof org.springframework.web.reactive.function.client.WebClientRequestException;
+    }
+
+    private FilmDetail parseHtmlToFilmDetail(String lang, String html, String url) {
+        return null;
+    }
+}

--- a/filmfest-film/src/main/java/com/filmfest/film/service/impl/FilmUrlScraperServiceImpl.java
+++ b/filmfest-film/src/main/java/com/filmfest/film/service/impl/FilmUrlScraperServiceImpl.java
@@ -1,0 +1,85 @@
+package com.filmfest.film.service.impl;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.filmfest.film.model.FilmUrl;
+import com.filmfest.film.repository.FilmUrlRepository;
+import com.filmfest.film.service.FilmUrlScraperService;
+import com.filmfest.film.exception.custom.CustomBadRequestException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class FilmUrlScraperServiceImpl implements FilmUrlScraperService {
+
+    private final FilmUrlRepository filmUrlRepository;
+    private final WebClient webClient = WebClient.builder()
+            .codecs(config -> config.defaultCodecs().maxInMemorySize(5 * 1024 * 1024))
+            .build();
+
+    private static final String BASE_URL = "https://sitgesfilmfestival.com";
+    private static final String FILM_URL_TEMPLATE = "https://sitgesfilmfestival.com/service/films/%d";
+
+    @Override
+    public Mono<Void> scrapeAndSaveFilmUrls(int year) {
+        return filmUrlRepository.deleteAll()
+                .thenMany(fetchFilmDataFromRemote(year))
+                .map(this::extractFilmUrl)
+                .flatMap(filmUrlRepository::save)
+                .then();
+    }
+
+    private Flux<Map<String, Object>> fetchFilmDataFromRemote(int year) {
+        String uri = String.format(FILM_URL_TEMPLATE, year);
+
+        return webClient.get()
+                .uri(uri)
+                .retrieve()
+                .bodyToMono(new ParameterizedTypeReference<Map<String, Object>>() {})
+                .flatMapMany(this::extractFilmList)
+                .onErrorResume(e -> {
+                    log.error("Failed to fetch or parse JSON from {}", uri, e);
+                    return Flux.error(new CustomBadRequestException("Error fetching/parsing JSON"));
+                });
+    }
+
+    @SuppressWarnings("unchecked")
+    private Flux<Map<String, Object>> extractFilmList(Map<String, Object> jsonMap) {
+        Object films = jsonMap.get("films");
+        if (films instanceof List<?>) {
+            return Flux.fromIterable((List<Map<String, Object>>) films);
+        } else {
+            log.error("Invalid JSON: expected 'films' to be a list");
+            return Flux.error(new CustomBadRequestException("Invalid JSON structure: expected 'films' to be a list"));
+        }
+    }
+
+
+    private FilmUrl extractFilmUrl(Map<String, Object> filmData) {
+        Map<String, String> urlMap = (Map<String, String>) filmData.get("url");
+        String slug = Optional.ofNullable(urlMap.get("ca"))
+                .map(url -> url.substring(url.lastIndexOf('/') + 1))
+                .orElse("unknown-" + System.currentTimeMillis());
+
+        return buildFilmUrlFromSlugAndMap(slug, urlMap);
+    }
+
+    private FilmUrl buildFilmUrlFromSlugAndMap(String slug, Map<String, String> urlMap) {
+        return FilmUrl.builder()
+                .id(slug)
+                .fullUrlCa(BASE_URL+ urlMap.get("ca"))
+                .fullUrlEs(BASE_URL + urlMap.get("es"))
+                .fullUrlEn(BASE_URL + urlMap.get("en"))
+                .build();
+    }
+}

--- a/filmfest-film/src/main/resources/application.properties
+++ b/filmfest-film/src/main/resources/application.properties
@@ -1,1 +1,7 @@
 spring.application.name=filmfest-film
+
+server.port=8081
+spring.data.mongodb.database=filmfest_film
+
+springdoc.api-docs.path=/v3/api-docs
+springdoc.swagger-ui.path=/swagger-ui.html


### PR DESCRIPTION
## feat: add filmfest-film service and controller layers (#24)

User Story: #41 [https://tree.taiga.io/project/tonijimenez72-filmer/task/24](url)

This PR introduces the service and controller layers for the filmfest-film microservice. It includes:

### Changes
- Add FilmUrlScraperService class: fetch film URLs and persist.
- Add FilmDetailScraperService class: fetch film details and persist.
- Add DatabaseAdminService class: database maintenance .
- Add FilmController class with the endpoints: 
  - POST /api/films/imports/sitges/{year}.
  - DELETE /api/films.
 - Updated build.gradle in filmfest-backend: disable packaging (bootJar).
 - Updated build.gradle in filmfest-film: Updated 'org.springdoc:springdoc-openapi-starter-webflux-ui' version '2.8.9'.
 - Updated application.properties:
  - Updated Server port: 8081.
  - Added Filmfest.Film database name: filmfest_film.
  - Added Swagger config.
 
  